### PR TITLE
WIP: add link to the event

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,12 +101,14 @@
 <script id="talk-template" type="text/x-handlebars-template">
   <tr>
     <td>
+      <a href="https://schedule.nixcon2017.org/en/nixcon2017/public/events/{{ id }}">
          {{ title }} {{#if subtitle}} – {{ subtitle }} {{/if}}
          {{#if persons}}
             by {{#each persons}}
                 {{ public_name }} {{#unless @last}} and {{/unless}}
             {{/each}}
          {{/if}}
+      </a>
     </td>
   </tr>
 </script>


### PR DESCRIPTION
Most of the links currently return 404 on the other website. Only 7, 25 and 26 are valid between 0 and 40. I couldn't find a property in https://schedule.nixcon2017.org/en/nixcon2017/public/schedule.json for those entries that makes them distinguishable from the rest.